### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/runners/utils/vwa_mgm_server/gradio_server.py
+++ b/runners/utils/vwa_mgm_server/gradio_server.py
@@ -115,11 +115,20 @@ def update_reset_info(state: gr.State, env_to_reset: List[str]):
     return state
 
 
+RESET_BASH_FILES = {
+    "env1": "/path/to/env1_reset.sh",
+    "env2": "/path/to/env2_reset.sh",
+    # Add other environments as needed
+}
+
 def _reset_envs(env_names: List[str]):
     all_sh_to_run = []
     for env in env_names:
-        sh_file = RESET_BASH_FILES[env]
-        all_sh_to_run.append(f"sh {sh_file}")
+        if env in RESET_BASH_FILES:
+            sh_file = RESET_BASH_FILES[env]
+            all_sh_to_run.append(f"sh {sh_file}")
+        else:
+            logger.warning(f"Invalid environment name: {env}")
 
     done_command = (
         f"""curl -X POST http://localhost:{SERVER_PORT}/call/done_resetting """


### PR DESCRIPTION
Fixes [https://github.com/microsoft/ExACT/security/code-scanning/1](https://github.com/microsoft/ExACT/security/code-scanning/1)

To fix the problem, we need to ensure that the commands executed by `subprocess.Popen` are not directly influenced by user input without proper validation. The best way to achieve this is to use a predefined list of allowed commands and ensure that only these commands can be executed. This approach prevents arbitrary command execution and mitigates the risk of command injection.

1. Define a dictionary of allowed environment reset scripts.
2. Validate the user input against this dictionary.
3. Construct the command string using only validated inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
